### PR TITLE
Remove SMS license requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 Before starting, you need the following:
 
 -   A MATLAB® Production Server™ license that meets the following conditions:
-    - Current on [Software Maintenance Service (SMS)](https://www.mathworks.com/services/maintenance.html).  
     - Linked to a [MathWorks Account](https://www.mathworks.com/mwaccount/).
     - Concurrent license type. To check your license type, see [MathWorks License Center](https://www.mathworks.com/licensecenter/). 
     - Configured to use a network license manager on the virtual network. By default, the deployment of MATLAB Production Server includes a network license manager, but you can also use an existing license manager. In either case, activate or move the license after deployment. For details, see [Configure MATLAB Production Server Licensing on the Cloud](https://www.mathworks.com/help/licensingoncloud/matlab-production-server-on-the-cloud.html).   


### PR DESCRIPTION
SMS is no longer a requirement for a MATLAB Production Service license.