### PR TITLE
Fix deploy to azure button

### DIFF
--- a/releases/R2024a/README.md
+++ b/releases/R2024a/README.md
@@ -4,7 +4,7 @@ Follow these steps to deploy the R2024a MATLAB Production Server reference archi
 ## Step 1. Launch Template
 To deploy resources on Azure, click **Deploy to Azure**. The Azure Portal open in your web browser.
 
- <a  href ="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmathworks-ref-arch%2Fmatlab-production-server-on-azure%2Fmaster%2Freleases%2FR2024a%2Ftemplates%2Fazuredeploy24a.json"  target ="_blank" >  <img  src ="http://azuredeploy.net/deploybutton.png" />  </a>
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmathworks-ref-arch%2Fmatlab-production-server-on-azure%2Fmaster%2Freleases%2FR2024a%2Ftemplates%2Fazuredeploy24a.json)
 
 > MATLAB Release: R2024a
 


### PR DESCRIPTION
Update readme.md to fix "deploy to azure" button not showing. This change will need to be done for earlier releases as well